### PR TITLE
Fix wrapping and margins on cards

### DIFF
--- a/source/docs/api-reference/api-usage/index.rst
+++ b/source/docs/api-reference/api-usage/index.rst
@@ -10,7 +10,7 @@ This section serves to provide basic API usage for the Phoenix Pro API. For full
 
 There are three major components to the Phoenix Pro API:
 
-.. grid:: 3
+.. grid:: 1 2 3 3
 
    .. grid-item-card:: Configs
 

--- a/source/docs/installation/configuring-your-device.rst
+++ b/source/docs/installation/configuring-your-device.rst
@@ -3,7 +3,8 @@ Configuring your Device
 
 All CTR-Electronics devices have an ID that distinguishes multiple devices of the same type on the same CAN bus. This should be configured to the user's preference. Firmware upgrading is also generally **required** for each new release of Phoenix Pro API. Please visit the relevant Tuner pages on how to complete these steps.
 
-.. grid:: 2
+.. grid:: 1 1 2 2
+   :gutter: 3
 
    .. grid-item-card:: Firmware Updating
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -37,7 +37,8 @@ Phoenix Pro currently offers the following features and will further expand:
 
    For news and updates about your CTR-Electronics device, please see the `blog <https://store.ctr-electronics.com/blog/>`__
 
-.. grid:: 3
+.. grid:: 1 2 3 3
+   :gutter: 3
 
    .. grid-item-card:: :octicon:`paintbrush` Installation
       :link: docs/installation/pro-installation
@@ -57,7 +58,8 @@ Phoenix Pro currently offers the following features and will further expand:
 
       Documentation for device specific configuration, troubleshooting and setup instructions.
 
-.. grid:: 3
+.. grid:: 1 2 3 3
+   :gutter: 3
 
    .. grid-item-card:: :octicon:`rocket` API Reference
       :link: docs/api-reference/index

--- a/source/index.rst
+++ b/source/index.rst
@@ -58,9 +58,6 @@ Phoenix Pro currently offers the following features and will further expand:
 
       Documentation for device specific configuration, troubleshooting and setup instructions.
 
-.. grid:: 1 2 3 3
-   :gutter: 3
-
    .. grid-item-card:: :octicon:`rocket` API Reference
       :link: docs/api-reference/index
       :link-type: doc


### PR DESCRIPTION
Closes #3 

- 1 2 3 3 represents the wrap policy of cards on size screens. From left to right, "1" represents 1 card on "small" screen size. "2" represents 2 cards on "medium" screen size (tablet), "3" represents 3 columns on large (>1200px) screen size and so-forth.
- `gutter` adds a margin around cards. When cards are wrapped, there is no top-bottom margin by default and this fixes that.