### PR TITLE
Add kS and Motion Magic Documentation

### DIFF
--- a/source/docs/api-reference/api-usage/talonfx-control-requests/closed-loop-requests.rst
+++ b/source/docs/api-reference/api-usage/talonfx-control-requests/closed-loop-requests.rst
@@ -16,7 +16,7 @@ All closed-loop control requests follow the naming pattern ``{ClosedLoopMode}{Co
 Gain Slots
 ----------
 
-It may be useful to switch between presets of gains in a motor controller, so the TalonFX supports multiple gain slots. All closed-loop control requests have a member variable ``Slot`` that can be assigned an integer ID to select the set of gains used by the closed-loop.
+It may be useful to switch between presets of gains in a motor controller, so the TalonFX supports multiple gain slots. All closed-loop control requests have a member variable ``Slot`` that can be assigned an integer ID to select the set of gains used by the closed-loop. The gain slots can be :doc:`configured in code </docs/api-reference/api-usage/configuration>` using ``Slot*Configs`` (`Java <https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/configs/Slot0Configs.html>`__, `C++ <https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1configs_1_1_slot0_configs.html>`__) objects.
 
 Velocity Control
 ----------------
@@ -218,6 +218,8 @@ Using Motion Magic in API
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Motion Magic is currently supported for all base :ref:`control output types <docs/api-reference/api-usage/talonfx-control-requests/talonfx-control-intro:control output types>`. The units of the output is determined by the control output type.
+
+The Motion Magic jerk, acceleration, and cruise velocity can be :doc:`configured in code </docs/api-reference/api-usage/configuration>` using a ``MotionMagicConfigs`` (`Java <https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/configs/MotionMagicConfigs.html>`__, `C++ <https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1configs_1_1_motion_magic_configs.html>`__) object.
 
 In Motion Magic, the gains should be configured as follows:
 

--- a/source/docs/api-reference/api-usage/talonfx-control-requests/closed-loop-requests.rst
+++ b/source/docs/api-reference/api-usage/talonfx-control-requests/closed-loop-requests.rst
@@ -243,9 +243,9 @@ In Motion Magic, the gains should be configured as follows:
          var slot0Configs = talonFXConfigs.Slot0Configs;
          slot0Configs.kS = 0.05; // Add 0.05 V output to overcome static friction
          slot0Configs.kV = 0.12; // A velocity target of 1 rps results in 0.12 V output
-         slot0Configs.kP = 24; // An error of 0.5 rotations results in 12 V output
+         slot0Configs.kP = 24; // A position error of 0.5 rotations results in 12 V output
          slot0Configs.kI = 0; // no output for integrated error
-         slot0Configs.kD = 0.1; // A velocity of 1 rps results in 0.1 V output
+         slot0Configs.kD = 0.1; // A velocity error of 1 rps results in 0.1 V output
 
          // set Motion Magic settings
          var motionMagicConfigs = talonFXConfigs.MotionMagicConfigs;
@@ -267,9 +267,9 @@ In Motion Magic, the gains should be configured as follows:
          auto& slot0Configs = talonFXConfigs.Slot0Configs;
          slot0Configs.kS = 0.05; // Add 0.05 V output to overcome static friction
          slot0Configs.kV = 0.12; // A velocity target of 1 rps results in 0.12 V output
-         slot0Configs.kP = 24; // An error of 0.5 rotations results in 12 V output
+         slot0Configs.kP = 24; // A position error of 0.5 rotations results in 12 V output
          slot0Configs.kI = 0; // no output for integrated error
-         slot0Configs.kD = 0.1; // A velocity of 1 rps results in 0.1 V output
+         slot0Configs.kD = 0.1; // A velocity error of 1 rps results in 0.1 V output
 
          // set Motion Magic settings
          auto& motionMagicConfigs = talonFXConfigs.MotionMagicConfigs;


### PR DESCRIPTION
Fixes https://github.com/CrossTheRoadElec/PhoenixPro-Documentation/issues/20 by adding documentation for the kS term to the Closed-Loop Control page.
Fixes https://github.com/CrossTheRoadElec/PhoenixPro-Documentation/issues/26 by adding documentation for what is Motion Magic, and configuring and controlling a device using Motion Magic.

Updated links to WPILib documentation for their new 2023 closed loop documentation.