### PR TITLE
Add note to gain conversion tables about other control output types

### DIFF
--- a/source/docs/api-reference/api-usage/migration-guide.rst
+++ b/source/docs/api-reference/api-usage/migration-guide.rst
@@ -252,6 +252,10 @@ Phoenix Pro
 Closed Loop Gains
 -----------------
 
+These tables are for translating Phoenix v5 gains to Phoenix Pro DutyCycle gains.
+
+.. note:: There are other :ref:`control output types <docs/api-reference/api-usage/talonfx-control-requests/talonfx-control-intro:control output types>` in Phoenix Pro that will change the magnitude of the gains.
+
 Position (DutyCycle)
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/source/docs/api-reference/api-usage/talonfx-control-requests/talonfx-control-intro.rst
+++ b/source/docs/api-reference/api-usage/talonfx-control-requests/talonfx-control-intro.rst
@@ -6,22 +6,22 @@ The TalonFX has a variety of open-loop and closed-loop control requests and supp
 Control Output Types
 --------------------
 
-The TalonFX supports three base control types: DutyCycle, Voltage, and TorqueCurrentFOC.
+The TalonFX supports three base control output types: DutyCycle, Voltage, and TorqueCurrentFOC.
 
 DutyCycle
 ^^^^^^^^^
 
-A DutyCycle control request outputs a proportion of the supply voltage, which typically ranges from -1.0 to 1.0, inclusive. This control type is typically used in systems where it is important to be capable of running at the maximum speed possible, such as in a typical robot drivetrain.
+A DutyCycle control request outputs a proportion of the supply voltage, which typically ranges from -1.0 to 1.0, inclusive. This control output type is typically used in systems where it is important to be capable of running at the maximum speed possible, such as in a typical robot drivetrain.
 
 Voltage
 ^^^^^^^
 
-A Voltage control request directly controls the output voltage of the motor. The output voltage is capped by the supply voltage to the device. Since the output of a Voltage control request is typically unaffected by the supply voltage, this control type results in more stable and reproducible behavior than a DutyCycle control request.
+A Voltage control request directly controls the output voltage of the motor. The output voltage is capped by the supply voltage to the device. Since the output of a Voltage control request is typically unaffected by the supply voltage, this control output type results in more stable and reproducible behavior than a DutyCycle control request.
 
 TorqueCurrentFOC
 ^^^^^^^^^^^^^^^^
 
-A TorqueCurrentFOC control request uses Field Oriented Control to directly control the output current of the motor. Unlike the other control types, where output roughly controls the velocity of the motor, a TorqueCurrentFOC request controls the **acceleration** of the motor.
+A TorqueCurrentFOC control request uses Field Oriented Control to directly control the output current of the motor. Unlike the other control output types, where output roughly controls the velocity of the motor, a TorqueCurrentFOC request controls the **acceleration** of the motor.
 
 Field Oriented Control
 ----------------------


### PR DESCRIPTION
This adds a note to the PID gain conversion tables in the migration guide, pointing out that the tables focus on the DutyCycle control output type, and other control output types will affect the magnitude of the gains.