### PR TITLE
Add documentation for non-FRC install

### DIFF
--- a/source/docs/canivore/canivore-setup.rst
+++ b/source/docs/canivore/canivore-setup.rst
@@ -6,19 +6,21 @@ Supported Systems
 
 Currently, the following systems are supported for CANivore development:
 
-- roboRIO
+- NI roboRIO
 
-- Windows 10, Windows 11 (x86-64)
+- Windows 10/11 x86-64
 
-- Linux desktop (x86-64)
+- Linux x86-64 (desktop)
+
+  - Ubuntu 22.04 or newer
+
+  - Debian Bullseye or newer
+
+- Linux ARM32 and ARM64 (Raspberry Pi, NVIDIA Jetson)
 
   - Ubuntu 20.04 or newer
 
-  - Debian Buster or newer
-
-- Raspberry Pi (Linux ARM 32-bit and 64-bit)
-
-- NVIDIA Jetson
+  - Debian Bullseye or newer
 
 .. note:: **Custom bit rates and CAN 2.0 are not supported at this time.** The parameters passed into SocketCAN are not applied by the firmware.
 

--- a/source/docs/canivore/canivore-setup.rst
+++ b/source/docs/canivore/canivore-setup.rst
@@ -50,7 +50,7 @@ After adding the sources, the kernel module can be installed and updated using t
    sudo apt update
    sudo apt install canivore-usb
 
-.. tip:: To get a robot application up and running quickly, check out our `SocketCAN example <https://github.com/CrossTheRoadElec/Phoenix-Linux-SocketCAN-Example/blob/master/example.cpp>`__.
+.. tip:: To get a robot application up and running quickly, check out our `non-FRC Linux example <https://github.com/CrossTheRoadElec/PhoenixPro-Linux-Example>`__.
 
 Viewing Attached CANivores
 --------------------------

--- a/source/docs/canivore/canivore-setup.rst
+++ b/source/docs/canivore/canivore-setup.rst
@@ -32,7 +32,7 @@ No additional steps are required. The roboRIO comes with the ``canivore-usb`` ke
 Linux (non-FRC)
 ^^^^^^^^^^^^^^^
 
-On non-FRC Linux systems, the ``canivore-usb`` kernel module must be installed to add SocketCAN support for the CANivore. The kernel module is distributed through our APT repository. Begin with adding this repository to your APT sources.
+On non-FRC Linux systems, the ``canivore-usb`` kernel module must be installed to add SocketCAN support for the CANivore. The kernel module is distributed through our APT repository. Begin with adding the repository to your APT sources.
 
 .. code-block:: bash
 

--- a/source/docs/installation/pro-installation.rst
+++ b/source/docs/installation/pro-installation.rst
@@ -91,6 +91,8 @@ Online
          sudo apt update
          sudo apt install phoenix-pro
 
+      .. tip:: To get a robot application up and running quickly, check out our `non-FRC Linux example <https://github.com/CrossTheRoadElec/PhoenixPro-Linux-Example>`__.
+
 Tuner X Installation
 --------------------
 

--- a/source/docs/installation/pro-installation.rst
+++ b/source/docs/installation/pro-installation.rst
@@ -27,7 +27,7 @@ The following targets are supported:
 Offline
 ^^^^^^^
 
-.. important:: Users using their CTR Electronics device outside of `FRC <https://www.firstinspires.org/robotics/frc>`__ should skip to the **Online** section of this article.
+.. important:: Users on non-Windows devices should skip to the :ref:`Online <docs/installation/pro-installation:online>` installation instructions.
 
 1. Download the `Phoenix Pro Installer <https://github.com/CrossTheRoadElec/Phoenix-Releases/releases>`__
 2. Navigate through the installer, ensuring applicable options are selected
@@ -61,9 +61,23 @@ Online
 
       .. important:: Devices on Phoenix Pro firmware **must** use the Phoenix Pro API. Device on Phoenix 5 firmware **must** use the Phoenix 5 API.
 
-   .. tab-item:: non-FRC
+   .. tab-item:: non-FRC (Linux)
 
-      Coming soon
+      Phoenix Pro is distributed through our APT repository. Begin with adding the repository to your APT sources.
+
+      .. code-block:: bash
+
+         sudo curl -s --compressed -o /usr/share/keyrings/ctr-pubkey.gpg "https://deb.ctr-electronics.com/ctr-pubkey.gpg"
+         sudo curl -s --compressed -o /etc/apt/sources.list.d/ctr<year>.list "https://deb.ctr-electronics.com/ctr<year>.list"
+
+      .. note:: ``<year>`` should be replaced with the year of Phoenix Pro software for which you have purchased licenses.
+
+      After adding the sources, Phoenix Pro can be installed and updated using the following:
+
+      .. code-block:: bash
+
+         sudo apt update
+         sudo apt install phoenix-pro
 
 Tuner X Installation
 --------------------

--- a/source/docs/installation/pro-installation.rst
+++ b/source/docs/installation/pro-installation.rst
@@ -18,11 +18,23 @@ System Requirements
 
 The following targets are supported:
 
-* Windows 10/11 x86-64
-* Linux x86-64 (Ubuntu 20.04 or higher)
-* Linux ARM 32-bit & 64-bit (Pi 3B+, Pi 4B, Jetson Nano)
-* macOS (regular simulation **only**)
 * NI roboRIO
+
+* Windows 10/11 x86-64
+
+* Linux x86-64 (desktop)
+
+  * Ubuntu 22.04 or newer
+
+  * Debian Bullseye or newer
+
+* Linux ARM32 and ARM64 (Raspberry Pi, NVIDIA Jetson)
+
+  * Ubuntu 20.04 or newer
+
+  * Debian Bullseye or newer
+
+* macOS (regular simulation **only**)
 
 Offline
 ^^^^^^^

--- a/source/index.rst
+++ b/source/index.rst
@@ -5,12 +5,24 @@ Welcome to the Phoenix Pro documentation. Individuals looking for `Phoenix 5` do
 
 The Phoenix Pro software framework allows you to control and configure your `CTR Electronics <https://store.ctr-electronics.com/>`__ Phoenix Pro Devices. Phoenix Pro represents a complete rewrite of the software framework over the existing Phoenix 5 framework. With Phoenix Pro, users have access to many new features that expand the control the user has over their devices.
 
-.. note:: A changelog containing API, Tuner and Firmware changes is available `here <https://api.ctr-electronics.com/changelog>`__, and a Phoenix 5 migration guide is available :doc:`here </docs/api-reference/api-usage/migration-guide/index>`.
-
 .. card:: CTR Electronics Blog
    :link: https://store.ctr-electronics.com/blog/
 
-   For news and updates about your CTR Electronics device, please see the `blog <https://store.ctr-electronics.com/blog/>`__
+   For news and updates about your CTR Electronics device, please check out our `blog <https://store.ctr-electronics.com/blog/>`__.
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+
+   .. grid-item-card:: Changelog
+      :link: https://api.ctr-electronics.com/changelog
+
+      A changelog containing API, Tuner and Firmware changes is available `here <https://api.ctr-electronics.com/changelog>`__.
+
+   .. grid-item-card:: Migration Guide
+      :link: docs/api-reference/api-usage/migration-guide/index
+      :link-type: doc
+
+      A Phoenix 5 migration guide is available :doc:`here </docs/api-reference/api-usage/migration-guide/index>`.
 
 .. grid:: 1 2 3 3
    :gutter: 3


### PR DESCRIPTION
This PR adds documentation for installing Phoenix Pro on non-FRC Debian-based systems using APT. It also updates the system requirements to reflect the newer compiler versions used this past season.