### PR TITLE
Add section to migration guide for common status signals

### DIFF
--- a/source/docs/api-reference/api-usage/migration-guide/status-signals-guide.rst
+++ b/source/docs/api-reference/api-usage/migration-guide/status-signals-guide.rst
@@ -130,3 +130,99 @@ Changing Update Frequency (Status Frame Period)
                m_talonFX.GetPosition().SetUpdateFrequency(5_Hz);
 
 .. important:: Currently in Phoenix Pro, when different status signal frequencies are specified for signals that share a status frame, the last specified frequency is applied to the status frame. As a result, users should apply the slowest status frame frequencies first and the fastest frequencies last.
+
+Common Signals
+--------------
+
+Several signals have changed name or form in Phoenix Pro.
+
+General Signals
+^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :width: 100%
+
+   * - Phoenix 5
+     - Phoenix Pro
+
+   * - ``BusVoltage``
+     - ``SupplyVoltage``
+
+   * - ``Faults`` / ``StickyFaults`` (fills an object)
+     - ``Fault_*`` / ``StickyFault_*`` (individual faults)
+
+   * - ``FirmwareVersion``
+     - ``Version``
+
+Talon FX Signals
+^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :width: 100%
+
+   * - Phoenix 5
+     - Phoenix Pro
+
+   * - ``MotorOutputPercent``
+     - ``DutyCycle``
+
+   * - ``StatorCurrent``
+     - | ``StatorCurrent`` (motoring +, braking -)
+       | ``TorqueCurrent`` (forward +, reverse -)
+
+   * - ``Inverted`` (true/false)
+     - ``AppliedRotorPolarity`` (CCW+/CW+)
+
+   * - ``SelectedSensorPosition`` / ``SelectedSensorVelocity``
+     - ``Position`` / ``Velocity``
+
+   * - ``IntegratedSensorPosition`` / ``IntegratedSensorVelocity`` (in SensorCollection)
+     - ``RotorPosition`` / ``RotorVelocity``
+
+   * - ``ActiveTrajectory*`` (only Motion Magic® and the Motion Profile Executor)
+     - ``ClosedLoopReference*`` (all closed-loop control requests)
+
+   * - ``IsFwdLimitSwitchClosed`` / ``IsRevLimitSwitchClosed`` (true/false)
+     - ``GetForwardLimit`` / ``GetReverseLimit`` (Open/Closed)
+
+CANcoder Signals
+^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :width: 100%
+
+   * - Phoenix 5
+     - Phoenix Pro
+
+   * - ``MagnetFieldStrength``
+     - ``MagnetHealth``
+
+Pigeon 2 Signals
+^^^^^^^^^^^^^^^^
+
+.. note:: Many Pigeon 2 signal getters in Phoenix 5 fill a double array, such as ``YawPitchRoll``. In Phoenix Pro, these signals have been broken up into their individual components, such as ``Yaw``, ``Pitch``, and ``Roll``.
+
+.. list-table::
+   :header-rows: 1
+   :width: 100%
+
+   * - Phoenix 5
+     - Phoenix Pro
+
+   * - ``RawGyro``
+     - ``AngularVelocityX`` / ``AngularVelocityY`` / ``AngularVelocityZ``
+
+   * - ``6dQuaternion``
+     - ``QuatW`` / ``QuatX`` / ``QuatY`` / ``QuatZ``
+
+   * - ``BiasedAccelerometer``
+     - ``AccelerationX`` / ``AccelerationY`` / ``AccelerationZ``
+
+   * - ``BiasedMagnetometer``
+     - ``MagneticFieldX`` / ``MagneticFieldY`` / ``MagneticFieldZ``
+
+   * - ``RawMagnetometer``
+     - ``RawMagneticFieldX`` / ``RawMagneticFieldY`` / ``RawMagneticFieldZ``


### PR DESCRIPTION
Several status signals have changed names or form (filling an object vs getting individual components) in Phoenix Pro. This PR adds a few tables to the Status Signals page of the Migration Guide detailing the name changes.